### PR TITLE
Add support for optional dependency extras 

### DIFF
--- a/tests/test_unidep.py
+++ b/tests/test_unidep.py
@@ -2067,3 +2067,35 @@ def test_dot_in_package_name(
             Spec(name="ruamel.yaml", which="pip", identifier="17e5d607"),
         ],
     }
+
+
+@pytest.mark.parametrize("toml_or_yaml", ["toml", "yaml"])
+def test_parse_requirements_with_extras(
+    toml_or_yaml: Literal["toml", "yaml"],
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "requirements.yaml"
+    p.write_text(
+        textwrap.dedent(
+            """\
+            dependencies:
+              - numpy
+
+            optional_dependencies:
+              dev:
+                - pytest
+            """
+        ),
+    )
+
+    p = maybe_as_toml(toml_or_yaml, p)
+
+    requirements = parse_requirements(
+        p,
+        extras=[["dev"]],
+        verbose=False,
+    )
+
+    assert requirements.optional_dependencies["dev"]["pytest"][0].name == "pytest"
+
+    

--- a/unidep/_cli.py
+++ b/unidep/_cli.py
@@ -233,6 +233,17 @@ def _add_common_args(  # noqa: PLR0912, C901
             " to overwrite the pins of multiple packages.",
         )
 
+        if "extra" in options:
+            sub_parser.add_argument(
+                "--extra",
+                action="append",
+                default=[],
+                help=(
+                    "Include optional dependency group(s). "
+                    "Can be specified multiple times."
+                ),
+            )
+
 
 def _add_extra_flags(
     subparser: argparse.ArgumentParser,
@@ -315,6 +326,7 @@ def _parse_args() -> argparse.Namespace:
             "ignore-pin",
             "skip-dependency",
             "overwrite-pin",
+            "extra",
         },
     )
 
@@ -360,6 +372,7 @@ def _parse_args() -> argparse.Namespace:
             "skip-dependency",
             "overwrite-pin",
             "verbose",
+            "extra",
         },
     )
     install_all_help = (
@@ -402,6 +415,7 @@ def _parse_args() -> argparse.Namespace:
             "skip-dependency",
             "overwrite-pin",
             "verbose",
+            "extra",
         },
     )
 
@@ -460,6 +474,7 @@ def _parse_args() -> argparse.Namespace:
             "ignore-pin",
             "skip-dependency",
             "overwrite-pin",
+            "extra",
         },
     )
     _add_extra_flags(parser_lock, "conda-lock lock", "conda-lock", "--micromamba")
@@ -504,6 +519,7 @@ def _parse_args() -> argparse.Namespace:
             "ignore-pin",
             "skip-dependency",
             "overwrite-pin",
+            "extra",
         },
     )
     _add_extra_flags(
@@ -546,6 +562,7 @@ def _parse_args() -> argparse.Namespace:
                 "ignore-pin",
                 "skip-dependency",
                 "overwrite-pin",
+                "extra",
             },
         )
         sub_parser.add_argument(
@@ -744,6 +761,7 @@ def _install_command(  # noqa: PLR0912
     ignore_pins: list[str] | None = None,
     overwrite_pins: list[str] | None = None,
     skip_dependencies: list[str] | None = None,
+    extras: list[list[str]] | Literal["*"] | None = None,
     verbose: bool = False,
 ) -> None:
     """Install the dependencies of a single `requirements.yaml` or `pyproject.toml` file."""  # noqa: E501
@@ -756,6 +774,7 @@ def _install_command(  # noqa: PLR0912
         ignore_pins=ignore_pins,
         overwrite_pins=overwrite_pins,
         skip_dependencies=skip_dependencies,
+        extras=extras,
         verbose=verbose,
     )
     platforms = [identify_current_platform()]
@@ -906,6 +925,7 @@ def _merge_command(
     skip_dependencies: list[str],
     overwrite_pins: list[str],
     verbose: bool,
+    extras: list[list[str]] | Literal["*"] | None = None,
 ) -> None:  # pragma: no cover
     # When using stdout, suppress verbose output
     verbose = verbose and not stdout
@@ -927,6 +947,7 @@ def _merge_command(
         ignore_pins=ignore_pins,
         overwrite_pins=overwrite_pins,
         skip_dependencies=skip_dependencies,
+        extras=extras,
         verbose=verbose,
     )
     if not platforms:
@@ -961,6 +982,7 @@ def _pip_compile_command(
     verbose: bool,
     extra_flags: list[str],
     output_file: Path | None = None,
+    extras: list[list[str]] | Literal["*"] | None = None,
 ) -> None:
     if importlib.util.find_spec("piptools") is None:  # pragma: no cover
         print(
@@ -980,6 +1002,7 @@ def _pip_compile_command(
         ignore_pins=ignore_pins,
         overwrite_pins=overwrite_pins,
         skip_dependencies=skip_dependencies,
+        extras=extras,
         verbose=verbose,
     )
     resolved = resolve_conflicts(
@@ -1101,6 +1124,7 @@ def main() -> None:
             ignore_pins=args.ignore_pin,
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
+            extras=args.extra,
             verbose=args.verbose,
         )
     elif args.command == "pip":  # pragma: no cover
@@ -1124,6 +1148,7 @@ def main() -> None:
             ignore_pins=args.ignore_pin,
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
+            extras=args.extra,
             verbose=args.verbose,
         )
         resolved = resolve_conflicts(
@@ -1153,6 +1178,7 @@ def main() -> None:
             ignore_pins=args.ignore_pin,
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
+            extras=args.extra,
             verbose=args.verbose,
         )
     elif args.command == "install-all":
@@ -1205,6 +1231,7 @@ def main() -> None:
             ignore_pins=args.ignore_pin,
             skip_dependencies=args.skip_dependency,
             overwrite_pins=args.overwrite_pin,
+            extras=args.extra,
             extra_flags=args.extra_flags,
             output_file=args.output_file,
         )

--- a/unidep/_dependencies_parsing.py
+++ b/unidep/_dependencies_parsing.py
@@ -21,6 +21,7 @@ from unidep.utils import (
     is_pip_installable,
     parse_package_str,
     selector_from_comment,
+    split_path_and_extras,
     unidep_configured_in_toml,
     warn,
 )
@@ -138,7 +139,7 @@ class ParsedRequirements(NamedTuple):
     channels: list[str]
     platforms: list[Platform]
     requirements: dict[str, list[Spec]]
-
+    optional_dependencies: dict[str, dict[str, list[Spec]]]
 
 class Requirements(NamedTuple):
     """Requirements as CommentedSeq."""
@@ -191,56 +192,107 @@ def _get_local_dependencies(data: dict[str, Any]) -> list[str]:
     return []
 
 
-def parse_requirements(  # noqa: PLR0912
+def parse_requirements(
     *paths: Path,
     ignore_pins: list[str] | None = None,
     overwrite_pins: list[str] | None = None,
     skip_dependencies: list[str] | None = None,
+    extras: list[list[str]] | Literal["*"] | None = None,
     verbose: bool = False,
 ) -> ParsedRequirements:
     """Parse a list of `requirements.yaml` or `pyproject.toml` files."""
     ignore_pins = ignore_pins or []
     skip_dependencies = skip_dependencies or []
+
+    if extras is not None and extras != "*" and len(extras) != len(paths):
+        msg = (
+            f"Length of `extras` ({len(extras)}) "
+            f"must match number of paths ({len(paths)})."
+        )
+        raise ValueError(msg)
+
     overwrite_pins_map = _parse_overwrite_pins(overwrite_pins or [])
+
+    selected_extras: list[list[str]] = []
+
     requirements: dict[str, list[Spec]] = defaultdict(list)
+
+    optional_dependencies: dict[str, dict[str, list[Spec]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+
     channels: set[str] = set()
     platforms: set[Platform] = set()
-    datas = []
+
+    datas: list[dict[str, Any]] = []
     seen: set[Path] = set()
+
     yaml = YAML(typ="rt")
-    for p in paths:
+
+    for index, p in enumerate(paths):
+        path, path_extras = split_path_and_extras(str(p))
+
+        if extras is not None and extras != "*" and path_extras:
+            msg = (
+                "Cannot specify `extras` list when extras are already "
+                "given in the path."
+            )
+            raise ValueError(msg)
+
+        if extras == "*":
+            current_extras = []
+        elif extras is None:
+            current_extras = path_extras
+        else:
+            current_extras = extras[index]
+
+        selected_extras.append(current_extras)
+
         if verbose:
-            print(f"📄 Parsing `{p}`")
-        data = _load(p, yaml)
+            print(f"📄 Parsing `{path}`")
+
+        data = _load(path, yaml)
         datas.append(data)
-        seen.add(p.resolve())
+        seen.add(path.resolve())
 
         # Handle "local_dependencies" (or old name "includes", changed in 0.42.0)
         for include in _get_local_dependencies(data):
             try:
-                requirements_path = dependencies_filename(p.parent / include).resolve()
+                requirements_path = dependencies_filename(
+                    path.parent / include
+                ).resolve()
             except FileNotFoundError:
                 # Means that this is a local package that is not managed by unidep.
-                # We do not need to do anything here, just in `unidep install`.
                 continue
+
             if requirements_path in seen:
-                continue  # Avoids circular local_dependencies
+                continue
+
             if verbose:
                 print(f"📄 Parsing `{include}` from `local_dependencies`")
-            datas.append(_load(requirements_path, yaml))
+
+            loaded = _load(requirements_path, yaml)
+            datas.append(loaded)
+            selected_extras.append(current_extras)
             seen.add(requirements_path)
 
     identifier = -1
-    for data in datas:
+
+    for data, current_extras in zip(datas, selected_extras):
         for channel in data.get("channels", []):
             channels.add(channel)
+
         for _platform in data.get("platforms", []):
             platforms.add(_platform)
+
         if "dependencies" not in data:
             continue
+
         dependencies = data["dependencies"]
-        for i, dep in enumerate(data["dependencies"]):
+
+        for i, dep in enumerate(dependencies):
             identifier += 1
+
             if isinstance(dep, str):
                 specs = _parse_dependency(
                     dep,
@@ -252,10 +304,14 @@ def parse_requirements(  # noqa: PLR0912
                     overwrite_pins_map,
                     skip_dependencies,
                 )
+
                 for spec in specs:
                     requirements[spec.name].append(spec)
+
                 continue
+
             assert isinstance(dep, dict)
+
             for which in ["conda", "pip"]:
                 if which in dep:
                     specs = _parse_dependency(
@@ -268,11 +324,64 @@ def parse_requirements(  # noqa: PLR0912
                         overwrite_pins_map,
                         skip_dependencies,
                     )
+
                     for spec in specs:
                         requirements[spec.name].append(spec)
 
-    return ParsedRequirements(sorted(channels), sorted(platforms), dict(requirements))
+        optional = data.get("optional_dependencies", {})
 
+        for extra_name, deps in optional.items():
+
+            if extras != "*" and current_extras and extra_name not in current_extras:
+                continue
+
+            for i, dep in enumerate(deps):
+                identifier += 1
+
+                if isinstance(dep, str):
+                    specs = _parse_dependency(
+                        dep,
+                        deps,
+                        i,
+                        "both",
+                        identifier,
+                        ignore_pins,
+                        overwrite_pins_map,
+                        skip_dependencies,
+                    )
+
+                    for spec in specs:
+                        optional_dependencies[extra_name][spec.name].append(spec)
+
+                    continue
+
+                assert isinstance(dep, dict)
+
+                for which in ["conda", "pip"]:
+                    if which in dep:
+                        specs = _parse_dependency(
+                            dep[which],
+                            dep,
+                            which,
+                            which,  # type: ignore[arg-type]
+                            identifier,
+                            ignore_pins,
+                            overwrite_pins_map,
+                            skip_dependencies,
+                        )
+
+                        for spec in specs:
+                            optional_dependencies[extra_name][spec.name].append(spec)
+
+    return ParsedRequirements(
+        sorted(channels),
+        sorted(platforms),
+        dict(requirements),
+        {
+            extra: dict(packages)
+            for extra, packages in optional_dependencies.items()
+        },
+    )
 
 # Alias for backwards compatibility
 parse_yaml_requirements = parse_requirements

--- a/unidep/utils.py
+++ b/unidep/utils.py
@@ -150,10 +150,50 @@ class ParsedPackageStr(NamedTuple):
     selector: str | None = None
 
 
+def split_path_and_extras(s: str) -> tuple[Path, list[str]]:
+    """Split a path from trailing extras.
+
+    Returns a tuple containing the path and a list of extras.
+    """
+    if not s.endswith("]"):
+        return Path(s), []
+
+    start = s.rfind("[")
+
+    if start == -1:
+        return Path(s), []
+
+    extras_str = s[start + 1 : -1]
+    extras = [extra.strip() for extra in extras_str.split(",") if extra.strip()]
+
+    path = Path(s[:start])
+
+    return path, extras
+
+
+
+class PathWithExtras(NamedTuple):
+    """A path together with optional dependency groups."""
+
+    path: Path
+    extras: list[str]
+
+    @property
+    def path_with_extras(self) -> Path:
+        """Return the path with extras appended."""
+        if not self.extras:
+            return self.path
+
+        extras = ",".join(self.extras)
+        return Path(f"{self.path}[{extras}]")
+
+    
+
+
 def parse_package_str(package_str: str) -> ParsedPackageStr:
     """Splits a string into package name, version pinning, and platform selector."""
     # Regex to match package name, version pinning, and optionally platform selector
-    name_pattern = r"[a-zA-Z0-9_.-]+"
+    name_pattern = r"[a-zA-Z0-9_.-]+(?:\[[^\]]+\])?"
     version_pin_pattern = r".*?"
     selector_pattern = r"[a-z0-9\s]+"
     pattern = rf"({name_pattern})\s*({version_pin_pattern})?(:({selector_pattern}))?$"


### PR DESCRIPTION
## Summary

- Add support for parsing optional dependency extras
- Add `--extra` CLI option
- Add tests for parsing extras
- Update CLI help text

## Testing

```bash
pytest tests/test_unidep.py --no-cov